### PR TITLE
ci: migrate workflows to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   verify:
     name: 🛡️ Verify & Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/coolify-deploy.yml
+++ b/.github/workflows/coolify-deploy.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy:
     name: Trigger Coolify Deployment
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     timeout-minutes: 3
     steps:
       - name: Connect to Tailscale

--- a/.github/workflows/ecosystem-drift.yml
+++ b/.github/workflows/ecosystem-drift.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   analyze-drift:
     name: "Architectural Drift Analysis"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     timeout-minutes: 10
     steps:
       - name: Checkout WarRoom (Baseline)

--- a/.github/workflows/governance-guard.yml
+++ b/.github/workflows/governance-guard.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   audit-workflows:
     name: Audit Workflow Standards
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/librarian.yml
+++ b/.github/workflows/librarian.yml
@@ -35,14 +35,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.4.1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Create maintenance branch
         run: |

--- a/.github/workflows/librarian.yml
+++ b/.github/workflows/librarian.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   audit:
     name: 🔍 Run Librarian Audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,7 +126,7 @@ jobs:
     name: 📬 Create Maintenance PR
     needs: audit
     if: needs.audit.outputs.changes_made == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     steps:
       - uses: actions/checkout@v4
       - name: Create Pull Request

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -91,14 +91,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.4.1
+
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Create maintenance branch
         run: |

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -52,7 +52,7 @@ jobs:
   # ============================================================================
   preflight:
     name: 🛫 Pre-flight Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
@@ -80,7 +80,7 @@ jobs:
     name: 🔧 Run Maintenance
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
 
     outputs:
       changes_made: ${{ steps.commit.outputs.changes_detected }}
@@ -205,7 +205,7 @@ jobs:
     if: |
       needs.maintenance.outputs.changes_made == 'true' &&
       inputs.skip_pr != true
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     steps:
       - uses: actions/checkout@v4
 
@@ -228,7 +228,7 @@ jobs:
     name: 🚨 Notify Failure
     needs: [preflight, maintenance]
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     steps:
       - name: Create failure issue
         uses: actions/github-script@v8

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   heal:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, panopticon, ci, small]
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Migrates standard ubuntu-latest CI/CD workflows to run on the panopticon-ci-runner self-hosted runner to bypass account billing limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI infrastructure and build configuration.

---

**Note:** Dessa ändringar är interna infrastrukturförbättringar som inte påverkar användarupplevelsen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->